### PR TITLE
Make SequentialSampler be in the same order

### DIFF
--- a/torch/utils/data/sampler.py
+++ b/torch/utils/data/sampler.py
@@ -31,7 +31,7 @@ class SequentialSampler(Sampler):
         self.data_source = data_source
 
     def __iter__(self):
-        return iter(range(len(self.data_source)))
+        return iter(self.data_source)
 
     def __len__(self):
         return len(self.data_source)


### PR DESCRIPTION
The original function does not return a sequence that is the same as the input order. It returns a natural number sequence no matter what the user enters. We need to fix it or explain it on the documentation.